### PR TITLE
Updated mistake in pysqldf spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ joins and aggregations are also supported
      INNER JOIN
         births b
            ON m.date = b.date;"""
->>> joined = pyqldf(q)
+>>> joined = pysqldf(q)
 >>> print joined.head()
                     date    beef  births
 403  2012-07-01 00:00:00  2200.8  368450


### PR DESCRIPTION
Updated mistake in `pysqldf` spelling, It was `pyqldf` instead of `pysqldf`